### PR TITLE
FEAT/#37 Navbar 기능을 컴포넌트화하여 layout level에서 사용

### DIFF
--- a/src/app/(auth)/login/email/page.tsx
+++ b/src/app/(auth)/login/email/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-import BackSVG from '@/static/svg/arrow-left-icon.svg'
 import XMarkSVG from '@/static/svg/close-circle-icon.svg'
 import EyesOffSVG from '@/static/svg/eye-close.svg'
 import EyesOnSVG from '@/static/svg/eye-open.svg'
@@ -45,16 +44,8 @@ export default function EmailLoginPage() {
 
   return (
     <div className="flex flex-col items-center">
-      {/* 이메일로 로그인 */}
-      <div className="w-full h-[60px] relative flex items-center justify-center py-[14px] mb-[60px] border-b border-[#d6d5d5] text-center text-[#565551]">
-        <Link href="/login" className="absolute left-7 cursor-pointer">
-          <BackSVG className="w-8 h-8 min-w-[24px] min-h-[24px]" />
-        </Link>
-        <span className="font-bold text-[1.5rem]">이메일로 로그인</span>
-      </div>
-
       {/* scon logo */}
-      <Link href="/login" className="mb-[5rem]">
+      <Link href="/login" className="mt-[3.75rem] mb-20">
         <LogoSVG className="w-48 h-14" />
       </Link>
 

--- a/src/app/(auth)/signup/[step]/page.tsx
+++ b/src/app/(auth)/signup/[step]/page.tsx
@@ -2,30 +2,16 @@
 
 'use client'
 
-import { useRouter } from 'next/navigation'
-
 import BasicInfoStep from '@/app/(auth)/signup/steps/BasicInfoStep.tsx'
 import JoinStep from '@/app/(auth)/signup/steps/JoinStep.tsx'
 import MoreInfoStep from '@/app/(auth)/signup/steps/MoreInfoStep.tsx'
 import ProfileStep from '@/app/(auth)/signup/steps/ProfileStep.tsx'
 import Step from '@/components/Step.tsx'
-import BackSVG from '@/static/svg/arrow-left-icon.svg'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function SignupPage() {
-  const router = useRouter()
   return (
     <div className="flex flex-col">
-      <div className="w-full h-[60px] relative flex items-center justify-center py-[14px] border-b border-[#d6d5d5] text-center text-[#565551]">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="absolute left-7 cursor-pointer"
-        >
-          <BackSVG className="w-8 h-8 min-w-[24px] min-h-[24px]" />
-        </button>
-        <span className="font-bold text-[1.5rem]">회원가입</span>
-      </div>
       <Step name="basic">
         <BasicInfoStep />
       </Step>

--- a/src/app/(home)/main/page.tsx
+++ b/src/app/(home)/main/page.tsx
@@ -1,13 +1,11 @@
 import A2HSModal from '@/components/a2hs/index.tsx'
 import Carousel from '@/components/Carousel.tsx'
 import Footer from '@/components/footer/index.tsx'
-import Navbar from '@/components/Navbar/index.tsx'
 import StageContainer from '@/features/event/components/stage/index.tsx'
 
 export default function Mainpage() {
   return (
     <div className="w-full h-full">
-      <Navbar />
       <div className="flex flex-col  px-7 pt-10  pb-20 gap-20">
         <Carousel />
         <StageContainer />

--- a/src/app/(home)/search/page.tsx
+++ b/src/app/(home)/search/page.tsx
@@ -2,7 +2,6 @@
 
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import Filter from '@/app/(home)/search/_components/Filter.tsx'
@@ -11,27 +10,14 @@ import SearchBar from '@/app/(home)/search/_components/SearchBar.tsx'
 import StageCard from '@/app/(home)/search/_components/StageCard.tsx'
 import Tab from '@/app/(home)/search/_components/Tab.tsx'
 import { OvenList, StageList, TabList } from '@/constants/search/index.ts'
-import BackSVG from '@/static/svg/arrow-left-icon.svg'
 
 export default function SearchPage() {
   const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined)
   const [activeTab, setActiveTab] = useState<'oven' | 'stage'>('oven')
   const [filterQuery, setFilterQuery] = useState<string | undefined>(undefined)
-  const router = useRouter()
 
   return (
     <div className="flex flex-col">
-      {/* 상단바 */}
-      <div className="w-full h-[60px] relative flex items-center justify-center py-[14px] border-b border-[#d6d5d5] text-center text-[#565551]">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="absolute left-7 cursor-pointer"
-        >
-          <BackSVG className="w-8 h-8 min-w-[24px] min-h-[24px]" />
-        </button>
-        <span className="font-bold text-[1.5rem]">검색</span>
-      </div>
       {/* 검색바 */}
       <SearchBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
       {/* 탭 분류 */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import localFont from 'next/font/local'
 
 import Provider from '@/app/providers.tsx'
+import Navbar from '@/components/Navbar/index.tsx'
 
 const pretendard = localFont({
   src: '../static/fonts/PretendardVariable.woff2',
@@ -54,7 +55,10 @@ export default function RootLayout({
         className={`${pretendard.className} w-full h-full min-h-dvh flex justify-center`}
       >
         <div className="w-full h-full min-h-screen max-w-[600px] sm:border-l-0.5 sm:border-r-0.5 border-border">
-          <Provider>{children}</Provider>
+          <Provider>
+            <Navbar />
+            {children}
+          </Provider>
         </div>
       </body>
     </html>

--- a/src/components/Navbar/NavbarWithGoback.tsx
+++ b/src/components/Navbar/NavbarWithGoback.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+
+import BackSVG from '@/static/svg/arrow-left-icon.svg'
+
+interface NavbarWithGobackProps {
+  nameList: string[]
+}
+
+const DOMAIN_NAME_MAPPING: {
+  [key: string]: string
+} = {
+  login: '로그인',
+  email: '이메일 로그인',
+  find: '아이디 · 비밀번호',
+  signup: '회원가입',
+  search: '검색',
+  detail: '오븐 상세',
+}
+
+const getNameFromDomainMapping = (nameList: string[]) => {
+  const index = nameList.length >= 2 ? 1 : 0
+  return (
+    DOMAIN_NAME_MAPPING[nameList[index]] || DOMAIN_NAME_MAPPING[nameList[0]]
+  )
+}
+
+export default function NavbarWithGoback({ nameList }: NavbarWithGobackProps) {
+  const name = getNameFromDomainMapping(nameList)
+
+  return (
+    <div className="abolute top-0 w-full h-[60px] relative flex items-center justify-center py-[14px] border-b border-[#d6d5d5] text-center text-[#565551]">
+      <Link href="/login" className="absolute left-7 cursor-pointer">
+        <BackSVG className="w-8 h-8 min-w-[24px] min-h-[24px]" />
+      </Link>
+      <span className="font-bold text-[1.5rem]">{name}</span>
+    </div>
+  )
+}

--- a/src/components/Navbar/NavbarWithoutGoback.tsx
+++ b/src/components/Navbar/NavbarWithoutGoback.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import AlarmSVG from '@/static/svg/navbar/nav-alarm-icon.svg'
+import LogoSVG from '@/static/svg/navbar/nav-logo-icon.svg'
+import MenuSVG from '@/static/svg/navbar/nav-menu-icon.svg'
+import SearchSVG from '@/static/svg/navbar/nav-search-icon.svg'
+
+export default function NavbarWithoutGoback() {
+  const router = useRouter()
+
+  const handleAlarmClick = () => {}
+
+  const handleLogoClick = () => {
+    router.push('/main')
+  }
+
+  const handleSearchClick = () => {
+    router.push('/search')
+  }
+
+  const handleMenuClick = () => {
+    router.push('/menu')
+  }
+
+  return (
+    <div className="w-full h-[60px] flex items-center relative px-7 border-b-0.5 border-border">
+      {/* 왼쪽 div */}
+      <div className="w-full flex justify-start absolute left-7 cursor-pointer">
+        <div role="presentation" id="alarm" onClick={handleAlarmClick}>
+          <AlarmSVG />
+        </div>
+      </div>
+
+      {/* 가운데 div */}
+      <div className="w-full flex justify-center absolute left-1/2 -translate-x-1/2 cursor-pointer">
+        <div role="presentation" id="alarm" onClick={handleLogoClick}>
+          <LogoSVG />
+        </div>
+      </div>
+
+      {/* 오른쪽 div */}
+      <div className="w-full flex gap-2 justify-end absolute right-7 cursor-pointer">
+        <div role="presentation" id="alarm" onClick={handleSearchClick}>
+          <SearchSVG />
+        </div>
+        <div role="presentation" id="alarm" onClick={handleMenuClick}>
+          <MenuSVG />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,56 +1,18 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-
 'use client'
 
-import { useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 
-import AlarmSVG from '@/static/svg/navbar/nav-alarm-icon.svg'
-import LogoSVG from '@/static/svg/navbar/nav-logo-icon.svg'
-import MenuSVG from '@/static/svg/navbar/nav-menu-icon.svg'
-import SearchSVG from '@/static/svg/navbar/nav-search-icon.svg'
+import NavbarWithGoback from '@/components/Navbar/NavbarWithGoback.tsx'
+import NavbarWithoutGoback from '@/components/Navbar/NavbarWithoutGoback.tsx'
 
 export default function Navbar() {
-  const router = useRouter()
-
-  const handleAlarmClick = () => {}
-
-  const handleLogoClick = () => {
-    router.push('/main')
+  const pathname = usePathname()
+  const domainList = pathname.split('/').filter(Boolean)
+  if (domainList[0] === 'menu') {
+    return null
   }
-
-  const handleSearchClick = () => {
-    router.push('/search')
+  if (domainList[0] === 'main') {
+    return <NavbarWithoutGoback />
   }
-
-  const handleMenuClick = () => {
-    router.push('/menu')
-  }
-
-  return (
-    <div className="w-full h-[60px] flex items-center relative px-7 border-b-0.5 border-border">
-      {/* 왼쪽 div */}
-      <div className="w-full flex justify-start absolute left-7 cursor-pointer">
-        <div role="presentation" id="alarm" onClick={handleAlarmClick}>
-          <AlarmSVG />
-        </div>
-      </div>
-
-      {/* 가운데 div */}
-      <div className="w-full flex justify-center absolute left-1/2 -translate-x-1/2 cursor-pointer">
-        <div role="presentation" id="alarm" onClick={handleLogoClick}>
-          <LogoSVG />
-        </div>
-      </div>
-
-      {/* 오른쪽 div */}
-      <div className="w-full flex gap-2 justify-end absolute right-7 cursor-pointer">
-        <div role="presentation" id="alarm" onClick={handleSearchClick}>
-          <SearchSVG />
-        </div>
-        <div role="presentation" id="alarm" onClick={handleMenuClick}>
-          <MenuSVG />
-        </div>
-      </div>
-    </div>
-  )
+  return <NavbarWithGoback nameList={domainList} />
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37

## 📝작업 내용

> 현재 프로젝트 규모를 고려했을때, Navbar 로직을 일원화할 수 있다고 판단하여 컴포넌트화 작업을 진행했습니다. 
Navbar는 크게 두 종류로, NavbarWithoutGoBack과 NavbarWithGoBack이 있습니다. 이는 뒤로 가기 기능을 기준으로 분류한 내용입니다. index에서 뒤로가기 기능을 기준으로 분기처리하고, 각 컴포넌트에서 세부 분기 작업을 진행합니다. 향후 세세한 로직이 변경될 수 있지만 현재의 로직을 준수할 거 같습니다. 

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/d883a6eb-7af5-4eb3-a409-cb0fb7f5b55f)

